### PR TITLE
Do not delete empty lines if we send python code to tmux

### DIFF
--- a/autoload/tbone.vim
+++ b/autoload/tbone.vim
@@ -368,6 +368,10 @@ function! tbone#send_keys(target, keys) abort
 
   if len(a:keys) > 1000
     let temp = tempname()
+    if has("win32unix")
+      " read/write seem faster by using the clipboard under Cygwin
+      let temp = '/dev/clipboard'
+    endif
     call writefile(split(a:keys, "\r", 1), temp, 'b')
     let out = system('tmux load-buffer '.temp.' \; paste-buffer -d -t '.pane_id)
   else

--- a/autoload/tbone.vim
+++ b/autoload/tbone.vim
@@ -316,10 +316,10 @@ function! tbone#write_command(bang, line1, line2, count, target) abort
     return 'echoerr '.string('Target pane required')
   endif
 
-  if &filetype=='python'
-    let keys = join(map(
-        \ getline(a:line1, a:line2),
-        \ 'substitute(v:val,"^\\s*","","")'),
+  " If the comment string (cms) is '#', then we try to remove the comment lines.
+  if &cms == '#%s'
+    let keys = join(filter(getline(a:line1, a:line2),
+        \ "v:val !~ '^\s*#'"),
         \ "\r")
   else
     let keys = join(filter(map(

--- a/autoload/tbone.vim
+++ b/autoload/tbone.vim
@@ -340,6 +340,11 @@ function! tbone#write_command(bang, line1, line2, count, target) abort
     let keys = join(filter(l, "v:val !~ '^\\s*#'"), "\r")
   endif
 
+  " If the line starts with a comment symbol (cms) '%', then we try to remove this comment line.
+  if &cms == '%%s'
+    let keys = join(filter(l, "v:val !~ '^\\s*%'"), "\r")
+  endif
+
   if a:count > 0
     let keys = get(g:, 'tbone_write_initialization', '').keys."\r"
   endif

--- a/autoload/tbone.vim
+++ b/autoload/tbone.vim
@@ -316,11 +316,19 @@ function! tbone#write_command(bang, line1, line2, count, target) abort
     return 'echoerr '.string('Target pane required')
   endif
 
-  let keys = join(filter(map(
+  if &filetype=='python'
+    let keys = join(map(
+        \ getline(a:line1, a:line2),
+        \ 'substitute(v:val,"^\\s*","","")'),
+        \ "\r")
+  else
+    let keys = join(filter(map(
         \ getline(a:line1, a:line2),
         \ 'substitute(v:val,"^\\s*","","")'),
         \ "!empty(v:val)"),
         \ "\r")
+  endif
+
   if a:count > 0
     let keys = get(g:, 'tbone_write_initialization', '').keys."\r"
   endif

--- a/autoload/tbone.vim
+++ b/autoload/tbone.vim
@@ -319,6 +319,11 @@ function! tbone#write_command(bang, line1, line2, count, target) abort
   " Remove empty lines otherwise sending multiple lines of code to ipython will cause error.
   let l = filter(getline(a:line1, a:line2), "!empty(v:val)")
 
+  " ipython REPL needs this 'return' key to commit a block of code
+  if &ft == 'python' && len(l) > 1 && strpart(l[-1], 0, 1) == ' '
+    call add(l, "\r")
+  endif
+
   " This is the original code that deletes the leading spaces of every line.
   " let keys = join(filter(map(
   "   \ getline(a:line1, a:line2),
@@ -331,9 +336,6 @@ function! tbone#write_command(bang, line1, line2, count, target) abort
     let keys = join(filter(l, "v:val !~ '^\\s*#'"), "\r")
   endif
 
-  " ipython REPL needs this 'return' key to commit a block of code
-  let keys .= "\r"
-
   if a:count > 0
     let keys = get(g:, 'tbone_write_initialization', '').keys."\r"
   endif
@@ -341,7 +343,7 @@ function! tbone#write_command(bang, line1, line2, count, target) abort
   try
     let pane_id = tbone#send_keys(target, keys)
     let g:tbone_write_pane = pane_id
-    echo len(keys).' keys sent to '.pane_id
+    " echo len(keys).' keys sent to '.pane_id
     return ''
   catch /.*/
     return 'echoerr '.string(v:exception)

--- a/autoload/tbone.vim
+++ b/autoload/tbone.vim
@@ -319,7 +319,7 @@ function! tbone#write_command(bang, line1, line2, count, target) abort
   " If the comment string (cms) is '#', then we try to remove the comment lines.
   if &cms == '#%s'
     let keys = join(filter(getline(a:line1, a:line2),
-        \ "v:val !~ '^\s*#'"),
+        \ "v:val !~ '^\\s*#'"),
         \ "\r")
   else
     let keys = join(filter(map(

--- a/autoload/tbone.vim
+++ b/autoload/tbone.vim
@@ -316,18 +316,23 @@ function! tbone#write_command(bang, line1, line2, count, target) abort
     return 'echoerr '.string('Target pane required')
   endif
 
-  " If the comment string (cms) is '#', then we try to remove the comment lines.
+  " Remove empty lines otherwise sending multiple lines of code to ipython will cause error.
+  let l = filter(getline(a:line1, a:line2), "!empty(v:val)")
+
+  " This is the original code that deletes the leading spaces of every line.
+  " let keys = join(filter(map(
+  "   \ getline(a:line1, a:line2),
+  "   \ 'substitute(v:val,"^\\s*","","")'),
+  "   \ "!empty(v:val)"),
+  "   \ "\r")
+
+  " If the line starts with a comment symbol (cms) '#', then we try to remove this comment line.
   if &cms == '#%s'
-    let keys = join(filter(getline(a:line1, a:line2),
-        \ "v:val !~ '^\\s*#'"),
-        \ "\r")
-  else
-    let keys = join(filter(map(
-        \ getline(a:line1, a:line2),
-        \ 'substitute(v:val,"^\\s*","","")'),
-        \ "!empty(v:val)"),
-        \ "\r")
+    let keys = join(filter(l, "v:val !~ '^\\s*#'"), "\r")
   endif
+
+  " ipython REPL needs this 'return' key to commit a block of code
+  let keys .= "\r"
 
   if a:count > 0
     let keys = get(g:, 'tbone_write_initialization', '').keys."\r"
@@ -371,3 +376,4 @@ function! tbone#send_keys(target, keys) abort
 endfunction
 
 " }}}1
+" vim: set fdm=syntax ft=vim sw=2 ts=2 tw=100 :

--- a/autoload/tbone.vim
+++ b/autoload/tbone.vim
@@ -336,12 +336,12 @@ function! tbone#write_command(bang, line1, line2, count, target) abort
   "   \ "\r")
 
   " If the line starts with a comment symbol (cms) '#', then we try to remove this comment line.
-  if &cms == '#%s'
+  if &cms == '#%s' || &cms == '# %s'
     let keys = join(filter(l, "v:val !~ '^\\s*#'"), "\r")
   endif
 
   " If the line starts with a comment symbol (cms) '%', then we try to remove this comment line.
-  if &cms == '%%s'
+  if &cms == '%%s' || &cms == '% %s'
     let keys = join(filter(l, "v:val !~ '^\\s*%'"), "\r")
   endif
 

--- a/autoload/tbone.vim
+++ b/autoload/tbone.vim
@@ -322,6 +322,10 @@ function! tbone#write_command(bang, line1, line2, count, target) abort
   " ipython REPL needs this 'return' key to commit a block of code
   if &ft == 'python' && len(l) > 1 && strpart(l[-1], 0, 1) == ' '
     call add(l, "\r")
+  " F# and Ocaml needs ';;' to commit a block of code
+  elseif &ft == 'fsharp' || &ft == 'ocaml'
+    let l[-1] .= ';;'
+    let keys = join(filter(l, "v:val !~ '^\\s*//'"), "\r")
   endif
 
   " This is the original code that deletes the leading spaces of every line.

--- a/autoload/tbone.vim
+++ b/autoload/tbone.vim
@@ -324,7 +324,7 @@ function! tbone#write_command(bang, line1, line2, count, target) abort
     call add(l, "\r")
   " F# and Ocaml needs ';;' to commit a block of code
   elseif &ft == 'fsharp' || &ft == 'ocaml'
-    let l[-1] .= ';;'
+    call add(l, ";;")
     let keys = join(filter(l, "v:val !~ '^\\s*//'"), "\r")
   endif
 


### PR DESCRIPTION
empty lines are meaningful separators in Python code. Deleting them will cause troubles in Python REPL. My hack is a quick fix. How about a global configurable option?
