### PR TITLE
Add display-popup tmux command to completion list

### DIFF
--- a/autoload/tbone.vim
+++ b/autoload/tbone.vim
@@ -161,6 +161,7 @@ let s:aliases = {
       \
       \ 'confirm':     'confirm-before',
       \ 'display':     'display-message',
+      \ 'popup':       'display-popup',
       \
       \ 'clearhist':   'clear-history',
       \ 'copyb':       'copy-buffer',


### PR DESCRIPTION
The `display-popup` command was [added in tmux v3.2](https://github.com/tmux/tmux/blob/22eb0334c325245e7a49610f91c7842cb6408f4d/CHANGES#L537-L539)